### PR TITLE
使用unicode图标

### DIFF
--- a/po/fcitx-cloudpinyin.pot
+++ b/po/fcitx-cloudpinyin.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: fcitx-dev@googlegroups.com\n"
-"POT-Creation-Date: 2013-03-24 13:00-0400\n"
+"POT-Creation-Date: 2013-04-02 13:41+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,7 +27,8 @@ msgstr ""
 
 #: src/fcitx-cloudpinyin.desc:1 src/fcitx-cloudpinyin.desc:7
 #: src/fcitx-cloudpinyin.desc:13 src/fcitx-cloudpinyin.desc:18
-#: src/fcitx-cloudpinyin.desc:28 src/fcitx-cloudpinyin.desc:34
+#: src/fcitx-cloudpinyin.desc:23 src/fcitx-cloudpinyin.desc:33
+#: src/fcitx-cloudpinyin.desc:39
 msgid "CloudPinyin"
 msgstr ""
 
@@ -40,37 +41,41 @@ msgid "Minimum Length of Pinyin To Trigger Cloud Pinyin"
 msgstr ""
 
 #: src/fcitx-cloudpinyin.desc:16
-msgid "Don't Show the '☁' hint"
+msgid "Don't Show the cloud word hint"
 msgstr ""
 
 #: src/fcitx-cloudpinyin.desc:21
-msgid "Cloud Pinyin Source"
-msgstr ""
-
-#: src/fcitx-cloudpinyin.desc:23
-msgid "Sogou"
-msgstr ""
-
-#: src/fcitx-cloudpinyin.desc:24
-msgid "QQ"
-msgstr ""
-
-#: src/fcitx-cloudpinyin.desc:25
-msgid "Google"
+msgid "Cloud word hint"
 msgstr ""
 
 #: src/fcitx-cloudpinyin.desc:26
-msgid "Baidu"
+msgid "Cloud Pinyin Source"
+msgstr ""
+
+#: src/fcitx-cloudpinyin.desc:28
+msgid "Sogou"
+msgstr ""
+
+#: src/fcitx-cloudpinyin.desc:29
+msgid "QQ"
+msgstr ""
+
+#: src/fcitx-cloudpinyin.desc:30
+msgid "Google"
 msgstr ""
 
 #: src/fcitx-cloudpinyin.desc:31
+msgid "Baidu"
+msgstr ""
+
+#: src/fcitx-cloudpinyin.desc:36
 msgid "Toggle Cloud Pinyin enabled status"
 msgstr ""
 
-#: src/fcitx-cloudpinyin.desc:32
+#: src/fcitx-cloudpinyin.desc:37
 msgid "Disable Cloud Pinyin When you are using mobile can save your network"
 msgstr ""
 
-#: src/fcitx-cloudpinyin.desc:37
+#: src/fcitx-cloudpinyin.desc:42
 msgid "Enabled"
 msgstr ""

--- a/po/fcitx-cloudpinyin.pot
+++ b/po/fcitx-cloudpinyin.pot
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/cloudpinyin.c:669
-msgid " (via cloud)"
+msgid " ☁"
 msgstr ""
 
 #: src/fcitx-cloudpinyin.conf.in:3
@@ -44,7 +44,7 @@ msgid "Minimum Length of Pinyin To Trigger Cloud Pinyin"
 msgstr ""
 
 #: src/fcitx-cloudpinyin.desc:16
-msgid "Don't Show the 'via cloud' hint"
+msgid "Don't Show the '☁' hint"
 msgstr ""
 
 #: src/fcitx-cloudpinyin.desc:21

--- a/po/fcitx-cloudpinyin.pot
+++ b/po/fcitx-cloudpinyin.pot
@@ -17,10 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/cloudpinyin.c:669
-msgid " ☁"
-msgstr ""
-
 #: src/fcitx-cloudpinyin.conf.in:3
 msgid "Cloud Pinyin"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -19,10 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: src/cloudpinyin.c:669
-msgid " ☁"
-msgstr " ☁"
-
 #: src/fcitx-cloudpinyin.conf.in:4
 msgid "Add Cloud Pinyin Support to Pinyin Input Method"
 msgstr "为拼音输入法加入云拼音支持"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -20,8 +20,8 @@ msgstr ""
 "X-Generator: Lokalize 1.5\n"
 
 #: src/cloudpinyin.c:669
-msgid "☁"
-msgstr "☁"
+msgid " ☁"
+msgstr " ☁"
 
 #: src/fcitx-cloudpinyin.conf.in:4
 msgid "Add Cloud Pinyin Support to Pinyin Input Method"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx\n"
 "Report-Msgid-Bugs-To: fcitx-dev@googlegroups.com\n"
-"POT-Creation-Date: 2013-03-24 13:00-0400\n"
+"POT-Creation-Date: 2013-04-02 13:41+0800\n"
 "PO-Revision-Date: 2013-03-24 13:01-0400\n"
 "Last-Translator: Weng Xuetian <wengxt@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-china@kde.org>\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "Add Cloud Pinyin Support to Pinyin Input Method"
 msgstr "为拼音输入法加入云拼音支持"
 
-#: src/fcitx-cloudpinyin.desc:26
+#: src/fcitx-cloudpinyin.desc:31
 msgid "Baidu"
 msgstr "百度"
 
@@ -35,29 +35,34 @@ msgstr "云拼音"
 msgid "Cloud Pinyin Candidate Word Order"
 msgstr "云拼音候选词顺序"
 
-#: src/fcitx-cloudpinyin.desc:21
+#: src/fcitx-cloudpinyin.desc:26
 msgid "Cloud Pinyin Source"
 msgstr "云拼音来源"
 
+#: src/fcitx-cloudpinyin.desc:21
+msgid "Cloud word hint"
+msgstr "云提示"
+
 #: src/fcitx-cloudpinyin.desc:1 src/fcitx-cloudpinyin.desc:7
 #: src/fcitx-cloudpinyin.desc:13 src/fcitx-cloudpinyin.desc:18
-#: src/fcitx-cloudpinyin.desc:28 src/fcitx-cloudpinyin.desc:34
+#: src/fcitx-cloudpinyin.desc:23 src/fcitx-cloudpinyin.desc:33
+#: src/fcitx-cloudpinyin.desc:39
 msgid "CloudPinyin"
 msgstr "云拼音"
 
-#: src/fcitx-cloudpinyin.desc:32
+#: src/fcitx-cloudpinyin.desc:37
 msgid "Disable Cloud Pinyin When you are using mobile can save your network"
 msgstr "在使用移动网络时禁用云拼音可以节省流量"
 
 #: src/fcitx-cloudpinyin.desc:16
-msgid "Don't Show the '☁' hint"
-msgstr "不显示‘☁’提示"
+msgid "Don't Show the cloud word hint"
+msgstr "不显示云提示"
 
-#: src/fcitx-cloudpinyin.desc:37
+#: src/fcitx-cloudpinyin.desc:42
 msgid "Enabled"
 msgstr "启用"
 
-#: src/fcitx-cloudpinyin.desc:25
+#: src/fcitx-cloudpinyin.desc:30
 msgid "Google"
 msgstr "Google"
 
@@ -65,15 +70,14 @@ msgstr "Google"
 msgid "Minimum Length of Pinyin To Trigger Cloud Pinyin"
 msgstr "最小触发云拼音的拼音长度"
 
-#: src/fcitx-cloudpinyin.desc:24
+#: src/fcitx-cloudpinyin.desc:29
 msgid "QQ"
 msgstr "QQ"
 
-#: src/fcitx-cloudpinyin.desc:23
+#: src/fcitx-cloudpinyin.desc:28
 msgid "Sogou"
 msgstr "搜狗"
 
-#: src/fcitx-cloudpinyin.desc:31
+#: src/fcitx-cloudpinyin.desc:36
 msgid "Toggle Cloud Pinyin enabled status"
 msgstr "切换云拼音启用状态"
-

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -20,8 +20,8 @@ msgstr ""
 "X-Generator: Lokalize 1.5\n"
 
 #: src/cloudpinyin.c:669
-msgid " (via cloud)"
-msgstr " (来自云)"
+msgid "☁"
+msgstr "☁"
 
 #: src/fcitx-cloudpinyin.conf.in:4
 msgid "Add Cloud Pinyin Support to Pinyin Input Method"
@@ -54,8 +54,8 @@ msgid "Disable Cloud Pinyin When you are using mobile can save your network"
 msgstr "在使用移动网络时禁用云拼音可以节省流量"
 
 #: src/fcitx-cloudpinyin.desc:16
-msgid "Don't Show the 'via cloud' hint"
-msgstr "不显示‘来自云’提示"
+msgid "Don't Show the '☁' hint"
+msgstr "不显示‘☁’提示"
 
 #: src/fcitx-cloudpinyin.desc:37
 msgid "Enabled"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -21,8 +21,8 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: src/cloudpinyin.c:669
-msgid " (via cloud)"
-msgstr "（來自雲）"
+msgid "☁"
+msgstr "☁"
 
 #: src/fcitx-cloudpinyin.conf.in:4
 msgid "Add Cloud Pinyin Support to Pinyin Input Method"
@@ -55,8 +55,8 @@ msgid "Disable Cloud Pinyin When you are using mobile can save your network"
 msgstr ""
 
 #: src/fcitx-cloudpinyin.desc:16
-msgid "Don't Show the 'via cloud' hint"
-msgstr "不顯示「來自雲」提示"
+msgid "Don't Show the '☁' hint"
+msgstr "不顯示「☁」提示"
 
 #: src/fcitx-cloudpinyin.desc:37
 msgid "Enabled"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fcitx\n"
 "Report-Msgid-Bugs-To: fcitx-dev@googlegroups.com\n"
-"POT-Creation-Date: 2013-03-24 13:00-0400\n"
+"POT-Creation-Date: 2013-04-02 13:41+0800\n"
 "PO-Revision-Date: 2012-09-11 00:12+0000\n"
 "Last-Translator: Alisha <alisha.4m@gmail.com>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/projects/p/fcitx/"
@@ -24,7 +24,7 @@ msgstr ""
 msgid "Add Cloud Pinyin Support to Pinyin Input Method"
 msgstr "為拼音輸入法加入雲拼音支援"
 
-#: src/fcitx-cloudpinyin.desc:26
+#: src/fcitx-cloudpinyin.desc:31
 msgid "Baidu"
 msgstr "百度"
 
@@ -36,29 +36,34 @@ msgstr "雲拼音"
 msgid "Cloud Pinyin Candidate Word Order"
 msgstr "雲拼音候選字順序"
 
-#: src/fcitx-cloudpinyin.desc:21
+#: src/fcitx-cloudpinyin.desc:26
 msgid "Cloud Pinyin Source"
 msgstr "雲拼音來源"
 
+#: src/fcitx-cloudpinyin.desc:21
+msgid "Cloud word hint"
+msgstr "雲提示"
+
 #: src/fcitx-cloudpinyin.desc:1 src/fcitx-cloudpinyin.desc:7
 #: src/fcitx-cloudpinyin.desc:13 src/fcitx-cloudpinyin.desc:18
-#: src/fcitx-cloudpinyin.desc:28 src/fcitx-cloudpinyin.desc:34
+#: src/fcitx-cloudpinyin.desc:23 src/fcitx-cloudpinyin.desc:33
+#: src/fcitx-cloudpinyin.desc:39
 msgid "CloudPinyin"
 msgstr "雲拼音"
 
-#: src/fcitx-cloudpinyin.desc:32
+#: src/fcitx-cloudpinyin.desc:37
 msgid "Disable Cloud Pinyin When you are using mobile can save your network"
 msgstr ""
 
 #: src/fcitx-cloudpinyin.desc:16
-msgid "Don't Show the '☁' hint"
-msgstr "不顯示「☁」提示"
+msgid "Don't Show the cloud word hint"
+msgstr "不顯示雲提示"
 
-#: src/fcitx-cloudpinyin.desc:37
+#: src/fcitx-cloudpinyin.desc:42
 msgid "Enabled"
 msgstr ""
 
-#: src/fcitx-cloudpinyin.desc:25
+#: src/fcitx-cloudpinyin.desc:30
 msgid "Google"
 msgstr "Google"
 
@@ -66,14 +71,14 @@ msgstr "Google"
 msgid "Minimum Length of Pinyin To Trigger Cloud Pinyin"
 msgstr "最小觸發雲拼音的拼音長度"
 
-#: src/fcitx-cloudpinyin.desc:24
+#: src/fcitx-cloudpinyin.desc:29
 msgid "QQ"
 msgstr "QQ"
 
-#: src/fcitx-cloudpinyin.desc:23
+#: src/fcitx-cloudpinyin.desc:28
 msgid "Sogou"
 msgstr "搜狗"
 
-#: src/fcitx-cloudpinyin.desc:31
+#: src/fcitx-cloudpinyin.desc:36
 msgid "Toggle Cloud Pinyin enabled status"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -21,8 +21,8 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: src/cloudpinyin.c:669
-msgid "☁"
-msgstr "☁"
+msgid " ☁"
+msgstr " ☁"
 
 #: src/fcitx-cloudpinyin.conf.in:4
 msgid "Add Cloud Pinyin Support to Pinyin Input Method"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -20,10 +20,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/cloudpinyin.c:669
-msgid " ☁"
-msgstr " ☁"
-
 #: src/fcitx-cloudpinyin.conf.in:4
 msgid "Add Cloud Pinyin Support to Pinyin Input Method"
 msgstr "為拼音輸入法加入雲拼音支援"

--- a/src/cloudpinyin.c
+++ b/src/cloudpinyin.c
@@ -666,7 +666,7 @@ void _CloudPinyinAddCandidateWord(FcitxCloudPinyin* cloudpinyin, const char* pin
     if (cloudpinyin->config.bDontShowSource)
         candWord.strExtra = NULL;
     else {
-        candWord.strExtra = strdup(" ☁");
+        candWord.strExtra = strdup(cloudpinyin->config.CloudWordHint);
         candWord.extraType = MSG_TIPS;
     }
 

--- a/src/cloudpinyin.c
+++ b/src/cloudpinyin.c
@@ -709,6 +709,12 @@ void CloudPinyinFillCandidateWord(FcitxCloudPinyin* cloudpinyin,
                 uint64_t ts = cloudCand->timestamp;
                 uint64_t curTs = CloudGetTimeStamp();
                 FcitxCandidateWordRemove(candList, candWord);
+                if (cloudpinyin->config.bDontShowSource) {
+                    cand->strExtra = NULL;
+                } else {
+                    cand->strExtra = strdup(cloudpinyin->config.CloudWordHint);
+                    cand->extraType = MSG_TIPS;
+                }
                 /* if cloud word is not on the first page.. impossible */
                 if (cloudidx < pagesize) {
                     /* if the duplication before cloud word */

--- a/src/cloudpinyin.c
+++ b/src/cloudpinyin.c
@@ -666,7 +666,7 @@ void _CloudPinyinAddCandidateWord(FcitxCloudPinyin* cloudpinyin, const char* pin
     if (cloudpinyin->config.bDontShowSource)
         candWord.strExtra = NULL;
     else {
-        candWord.strExtra = strdup(_(" ☁"));
+        candWord.strExtra = strdup(" ☁");
         candWord.extraType = MSG_TIPS;
     }
 

--- a/src/cloudpinyin.c
+++ b/src/cloudpinyin.c
@@ -666,7 +666,7 @@ void _CloudPinyinAddCandidateWord(FcitxCloudPinyin* cloudpinyin, const char* pin
     if (cloudpinyin->config.bDontShowSource)
         candWord.strExtra = NULL;
     else {
-        candWord.strExtra = strdup(_(" (via cloud)"));
+        candWord.strExtra = strdup(_(" ☁"));
         candWord.extraType = MSG_TIPS;
     }
 

--- a/src/cloudpinyin.h
+++ b/src/cloudpinyin.h
@@ -73,6 +73,7 @@ typedef struct {
     int iCandidateOrder;
     int iMinimumPinyinLength;
     boolean bDontShowSource;
+    char* CloudWordHint;
     CloudPinyinSource source;
     FcitxHotkeys hkToggle;
     boolean bEnabled;

--- a/src/cloudpinyinconifg.c
+++ b/src/cloudpinyinconifg.c
@@ -25,6 +25,7 @@ CONFIG_BINDING_BEGIN(FcitxCloudPinyinConfig);
 CONFIG_BINDING_REGISTER("CloudPinyin", "CandidateOrder", iCandidateOrder);
 CONFIG_BINDING_REGISTER("CloudPinyin", "MinimumPinyinLength", iMinimumPinyinLength);
 CONFIG_BINDING_REGISTER("CloudPinyin", "DontShowSource", bDontShowSource);
+CONFIG_BINDING_REGISTER("CloudPinyin", "CloudWordHint", CloudWordHint);
 CONFIG_BINDING_REGISTER("CloudPinyin", "Source", source);
 CONFIG_BINDING_REGISTER("CloudPinyin", "ToggleKey", hkToggle);
 CONFIG_BINDING_REGISTER("CloudPinyin", "Enabled", bEnabled);

--- a/src/fcitx-cloudpinyin.desc
+++ b/src/fcitx-cloudpinyin.desc
@@ -13,7 +13,12 @@ Description=Minimum Length of Pinyin To Trigger Cloud Pinyin
 [CloudPinyin/DontShowSource]
 Type=Boolean
 DefaultValue=True
-Description=Don't Show the '☁' hint
+Description=Don't Show the cloud word hint
+
+[CloudPinyin/CloudWordHint]
+Type=String
+DefaultValue= ☁
+Description=Cloud word hint
 
 [CloudPinyin/Source]
 Type=Enum

--- a/src/fcitx-cloudpinyin.desc
+++ b/src/fcitx-cloudpinyin.desc
@@ -13,7 +13,7 @@ Description=Minimum Length of Pinyin To Trigger Cloud Pinyin
 [CloudPinyin/DontShowSource]
 Type=Boolean
 DefaultValue=True
-Description=Don't Show the 'via cloud' hint
+Description=Don't Show the '☁' hint
 
 [CloudPinyin/Source]
 Type=Enum


### PR DESCRIPTION
原来那个via cloud总觉得有点各应，换成unicode效果凑合，但不是特别好，主要原因是这个图标偏下，不知道fcitx里有没有“上标”的功能。`..`配很这个图标效果倒还可以。

这个需要字体支持，不知道问题大不大。

那个笑脸符号没太看明白，是说云端词汇跟下面的重复了什么的？
只是觉得那个符号不太直观，偶尔出现了不知道什么意思，也不能重现。。
